### PR TITLE
Register lambdas even when fun.runtime is undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -125,8 +125,7 @@ module.exports = function(ServerlessPlugin, serverlessPath) {
              requestTemplates: [Object],
              responses: [Object] } ] }
        */
-
-        if( fun.runtime == 'nodejs' ) {
+        if( fun.runtime === undefined || fun.runtime == 'nodejs' ) {
           let handlerParts = fun.handler.split('/').pop().split('.');
           let handlerPath = path.join(fun._config.fullPath, handlerParts[0] + '.js');
           let handler;


### PR DESCRIPTION
 - Provides a workaround to allow our lambda functions to be registered correctly
 - Temporary fix for #14